### PR TITLE
Allow filter to ignore specific DataArrays during the tuple copy operation

### DIFF
--- a/AnisotropyFilters/AdaptiveAlignment.cpp
+++ b/AnisotropyFilters/AdaptiveAlignment.cpp
@@ -47,13 +47,10 @@
 #include "SIMPLib/Geometry/ImageGeom.h"
 #include "SIMPLib/SIMPLibVersion.h"
 #include "SIMPLib/Utilities/FileSystemPathHelper.h"
+#include "SIMPLib/FilterParameters/MultiDataArraySelectionFilterParameter.h"
 
-#if defined(__APPLE__)
-//  #include "sitkExplicitITK.h"
-#endif
 
 #include "Anisotropy/AnisotropyConstants.h"
-
 #include "Anisotropy/AnisotropyFilters/ItkBridge.h"
 
 #include "itkHoughTransform2DCirclesImageFilter.h"
@@ -75,7 +72,8 @@ AdaptiveAlignment::AdaptiveAlignment()
 , m_NewCellArrayName("")
 , m_MinRadius(0.0f)
 , m_MaxRadius(0.0f)
-, m_NumberCircles(0){
+, m_NumberCircles(0)
+{
 }
 
 // -----------------------------------------------------------------------------
@@ -133,7 +131,10 @@ void AdaptiveAlignment::setupFilterParameters()
     parameters.push_back(SIMPL_NEW_FLOAT_FP("Total Shift In X-Direction (Microns)", ShiftX, FilterParameter::Parameter, AdaptiveAlignment, 2));
     parameters.push_back(SIMPL_NEW_FLOAT_FP("Total Shift In Y-Direction (Microns)", ShiftY, FilterParameter::Parameter, AdaptiveAlignment, 2));
   }
-
+  {
+    MultiDataArraySelectionFilterParameter::RequirementType req;
+    parameters.push_back(SIMPL_NEW_MDA_SELECTION_FP("Attribute Arrays to Ignore", IgnoredDataArrayPaths, FilterParameter::Parameter, AdaptiveAlignment, req));
+  }
   setFilterParameters(parameters);
 }
 
@@ -756,6 +757,14 @@ void AdaptiveAlignment::execute()
   uint64_t currentPosition = 0;
 
   QList<QString> voxelArrayNames = m->getAttributeMatrix(getCellAttributeMatrixName())->getAttributeArrayNames();
+  for(const auto& dataArrayPath : m_IgnoredDataArrayPaths)
+  {
+    if(voxelArrayNames.contains(dataArrayPath.getDataArrayName()))
+    {
+      voxelArrayNames.removeAll(dataArrayPath.getDataArrayName());
+    }
+  }
+
   int64_t progIncrement = dims[2] / 100;
   int64_t prog = 1;
   int64_t progressInt = 0;
@@ -801,17 +810,17 @@ void AdaptiveAlignment::execute()
         currentPosition = (slice * dims[0] * dims[1]) + ((yspot + yshifts[i]) * dims[0]) + (xspot + xshifts[i]);
         if(int64_t((yspot + yshifts[i])) >= 0 && (yspot + yshifts[i]) <= dims[1] - 1 && int64_t((xspot + xshifts[i])) >= 0 && (xspot + xshifts[i]) <= dims[0] - 1)
         {
-          for(QList<QString>::iterator iter = voxelArrayNames.begin(); iter != voxelArrayNames.end(); ++iter)
+          for(const auto& arrayName : voxelArrayNames)
           {
-            IDataArray::Pointer p = m->getAttributeMatrix(getCellAttributeMatrixName())->getAttributeArray(*iter);
+            IDataArray::Pointer p = m->getAttributeMatrix(getCellAttributeMatrixName())->getAttributeArray(arrayName);
             p->copyTuple(currentPosition, newPosition);
           }
         }
         if(int64_t((yspot + yshifts[i])) < 0 || (yspot + yshifts[i]) > dims[1] - 1 || int64_t((xspot + xshifts[i])) < 0 || (xspot + xshifts[i]) > dims[0] - 1)
         {
-          for(QList<QString>::iterator iter = voxelArrayNames.begin(); iter != voxelArrayNames.end(); ++iter)
+          for(const auto& arrayName : voxelArrayNames)
           {
-            IDataArray::Pointer p = m->getAttributeMatrix(getCellAttributeMatrixName())->getAttributeArray(*iter);
+            IDataArray::Pointer p = m->getAttributeMatrix(getCellAttributeMatrixName())->getAttributeArray(arrayName);
             EXECUTE_FUNCTION_TEMPLATE(this, initializeArrayValues, p, p, newPosition)
           }
         }

--- a/AnisotropyFilters/AdaptiveAlignment.cpp
+++ b/AnisotropyFilters/AdaptiveAlignment.cpp
@@ -89,8 +89,8 @@ void AdaptiveAlignment::setupFilterParameters()
   FilterParameterVector parameters;
   QStringList linkedProps("AlignmentShiftFileName");
 
-  parameters.push_back(SIMPL_NEW_LINKED_BOOL_FP("Write Alignment Shift File", WriteAlignmentShifts, FilterParameter::Parameter, AdaptiveAlignment, linkedProps));
-  parameters.push_back(SIMPL_NEW_OUTPUT_FILE_FP("Alignment File", AlignmentShiftFileName, FilterParameter::Parameter, AdaptiveAlignment, "", "*.txt"));
+//  parameters.push_back(SIMPL_NEW_LINKED_BOOL_FP("Write Alignment Shift File", WriteAlignmentShifts, FilterParameter::Parameter, AdaptiveAlignment, linkedProps));
+//  parameters.push_back(SIMPL_NEW_OUTPUT_FILE_FP("Alignment File", AlignmentShiftFileName, FilterParameter::Parameter, AdaptiveAlignment, "", "*.txt"));
 
   {
     LinkedChoicesFilterParameter::Pointer parameter = LinkedChoicesFilterParameter::New();
@@ -189,7 +189,10 @@ void AdaptiveAlignment::dataCheck()
   tempPath.update(getDataContainerName(), getCellAttributeMatrixName(), "");
   getDataContainerArray()->getPrereqAttributeMatrixFromPath<AbstractFilter>(this, tempPath, -301);
 
-  FileSystemPathHelper::CheckOutputFile(this, "Alignment Shift File Name", getAlignmentShiftFileName(), true);
+  if(getWriteAlignmentShifts())
+  {
+    FileSystemPathHelper::CheckOutputFile(this, "Alignment Shift File Name", getAlignmentShiftFileName(), true);
+  }
 
   if(m_GlobalCorrection == 1)
   {
@@ -759,10 +762,7 @@ void AdaptiveAlignment::execute()
   QList<QString> voxelArrayNames = m->getAttributeMatrix(getCellAttributeMatrixName())->getAttributeArrayNames();
   for(const auto& dataArrayPath : m_IgnoredDataArrayPaths)
   {
-    if(voxelArrayNames.contains(dataArrayPath.getDataArrayName()))
-    {
-      voxelArrayNames.removeAll(dataArrayPath.getDataArrayName());
-    }
+    voxelArrayNames.removeAll(dataArrayPath.getDataArrayName());
   }
 
   int64_t progIncrement = dims[2] / 100;

--- a/AnisotropyFilters/AdaptiveAlignment.h
+++ b/AnisotropyFilters/AdaptiveAlignment.h
@@ -106,6 +106,9 @@ public:
   SIMPL_FILTER_PARAMETER(int, NumberCircles)
   Q_PROPERTY(int NumberCircles READ getNumberCircles WRITE setNumberCircles)
 
+  SIMPL_FILTER_PARAMETER(QVector<DataArrayPath>, IgnoredDataArrayPaths)
+  Q_PROPERTY(QVector<DataArrayPath> IgnoredDataArrayPaths READ getIgnoredDataArrayPaths WRITE setIgnoredDataArrayPaths)
+
   /**
   * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class
   */

--- a/AnisotropyFilters/SteinerCompact.cpp
+++ b/AnisotropyFilters/SteinerCompact.cpp
@@ -821,8 +821,8 @@ void SteinerCompact::find_all_vertices(std::vector<std::vector<float>>& vertices
 
 void SteinerCompact::output_vtk(std::vector<std::vector<float>>& vertices_x, std::vector<std::vector<float>>& vertices_y, std::vector<std::vector<float>>& radii, std::vector<std::vector<float>>& ROI)
 {
-  std::ofstream pom("pom.txt");
-  pom << m_VtkOutput << std::endl;
+//  std::ofstream pom("pom.txt");
+//  pom << m_VtkOutput << std::endl;
 
   FILE* vtk = nullptr;
 

--- a/ExamplePipelines/Anisotropy/02_Adaptive Alignment - Misorientation - Zero Shifts.json
+++ b/ExamplePipelines/Anisotropy/02_Adaptive Alignment - Misorientation - Zero Shifts.json
@@ -1,31 +1,36 @@
 {
     "0": {
+        "AngleRepresentation": 0,
         "CellAttributeMatrixName": "EBSD & SEM Scan Data",
         "CellEnsembleAttributeMatrixName": "Phase Data",
         "DataContainerName": "AlMgSc Data",
-        "FilterVersion": "6.2.327",
-        "Filter_Human_Label": "Read H5EBSD File",
+        "FilterVersion": "6.5.77",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Import H5EBSD File",
         "Filter_Name": "ReadH5Ebsd",
-        "InputFile": "Data/AlMgSc.h5ebsd",
+        "Filter_Uuid": "{4ef7f56b-616e-5a80-9e68-1da8f35ad235}",
+        "InputFile": "Data/Anisotropy/AlMgSc.h5ebsd",
         "RefFrameZDir": 2,
         "SelectedArrayNames": [
-            "Fit",
-            "SEM Signal",
-            "Confidence Index",
             "Image Quality",
             "Y Position",
-            "EulerAngles",
             "Phases",
-            "X Position"
+            "X Position",
+            "Confidence Index",
+            "Fit",
+            "EulerAngles",
+            "SEM Signal"
         ],
         "UseTransformations": 1,
         "ZEndIndex": 9,
         "ZStartIndex": 0
     },
     "1": {
-        "FilterVersion": "6.2.327",
+        "FilterVersion": "6.5.77",
+        "Filter_Enabled": true,
         "Filter_Human_Label": "Convert Orientation Representation",
         "Filter_Name": "ConvertOrientations",
+        "Filter_Uuid": "{e5629880-98c4-5656-82b8-c9fe2b9744de}",
         "InputOrientationArrayPath": {
             "Attribute Matrix Name": "EBSD & SEM Scan Data",
             "Data Array Name": "EulerAngles",
@@ -36,7 +41,7 @@
         "OutputType": 2
     },
     "2": {
-        "AlignmentShiftFileName": "TestDataAdaptiveAlignment-Misorientation-ZeroShifts.txt",
+        "AlignmentShiftFileName": "Data/Output/Anisotropy/TestDataAdaptiveAlignment-Misorientation-ZeroShifts.txt",
         "CellPhasesArrayPath": {
             "Attribute Matrix Name": "EBSD & SEM Scan Data",
             "Data Array Name": "Phases",
@@ -47,15 +52,29 @@
             "Data Array Name": "CrystalStructures",
             "Data Container Name": "AlMgSc Data"
         },
-        "FilterVersion": "6.2.327",
+        "FilterVersion": "1.2.724",
+        "Filter_Enabled": true,
         "Filter_Human_Label": "Adaptive Alignment (Misorientation)",
         "Filter_Name": "AdaptiveAlignmentMisorientation",
+        "Filter_Uuid": "{8ef88380-ece9-5f8e-a12d-d149d0856752}",
         "GlobalCorrection": 2,
         "GoodVoxelsArrayPath": {
             "Attribute Matrix Name": "EBSD & SEM Scan Data",
             "Data Array Name": "",
             "Data Container Name": "AlMgSc Data"
         },
+        "IgnoredDataArrayPaths": [
+            {
+                "Attribute Matrix Name": "EBSD & SEM Scan Data",
+                "Data Array Name": "X Position",
+                "Data Container Name": "AlMgSc Data"
+            },
+            {
+                "Attribute Matrix Name": "EBSD & SEM Scan Data",
+                "Data Array Name": "Y Position",
+                "Data Container Name": "AlMgSc Data"
+            }
+        ],
         "ImageDataArrayPath": {
             "Attribute Matrix Name": "EBSD & SEM Scan Data",
             "Data Array Name": "",
@@ -75,6 +94,6 @@
     "PipelineBuilder": {
         "Name": "02_Adaptive Alignment - Misorientation - Zero Shifts",
         "Number_Filters": 3,
-        "Version": "6.2"
+        "Version": 6
     }
 }

--- a/ExamplePipelines/Anisotropy/03_Adaptive Alignment - Mutual Information - SEM Images.json
+++ b/ExamplePipelines/Anisotropy/03_Adaptive Alignment - Mutual Information - SEM Images.json
@@ -1,42 +1,46 @@
 {
     "0": {
+        "AngleRepresentation": 0,
         "CellAttributeMatrixName": "EBSD & SEM Scan Data",
         "CellEnsembleAttributeMatrixName": "Phase Data",
         "DataContainerName": "AlMgSc Data",
-        "FilterVersion": "6.2.327",
-        "Filter_Human_Label": "Read H5EBSD File",
+        "FilterVersion": "6.5.77",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Import H5EBSD File",
         "Filter_Name": "ReadH5Ebsd",
-        "InputFile": "Data/AlMgSc.h5ebsd",
+        "Filter_Uuid": "{4ef7f56b-616e-5a80-9e68-1da8f35ad235}",
+        "InputFile": "Data/Anisotropy/AlMgSc.h5ebsd",
         "RefFrameZDir": 2,
         "SelectedArrayNames": [
-            "Y Position",
-            "Confidence Index",
             "Image Quality",
-            "SEM Signal",
+            "Y Position",
             "Phases",
+            "X Position",
+            "Confidence Index",
             "Fit",
             "EulerAngles",
-            "X Position"
+            "SEM Signal"
         ],
         "UseTransformations": 1,
         "ZEndIndex": 9,
         "ZStartIndex": 0
     },
     "1": {
-        "BoundsFile": "",
-        "CellAttributeMatrixName": "EBSD & SEM Scan Data",
+        "CellAttributeMatrixName": "EBSD SEM Scan Data",
         "DataContainerName": "SEMAlMgSc Data",
-        "FilterVersion": "6.2.327",
-        "Filter_Human_Label": "Import Images (3D Stack)",
-        "Filter_Name": "ImportImageStack",
-        "GeometryType": 0,
+        "FilterVersion": "1.0.477",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "ITK::Import Images (3D Stack)",
+        "Filter_Name": "ITKImportImageStack",
+        "Filter_Uuid": "{cf7d7497-9573-5102-bedd-38f86a6cdfd4}",
         "ImageDataArrayName": "ImageData",
         "InputFileListInfo": {
             "EndIndex": 9,
             "FileExtension": "tif",
             "FilePrefix": "AlMgSc-TD_",
             "FileSuffix": "",
-            "InputPath": "Data/tif",
+            "IncrementIndex": 1,
+            "InputPath": "Data/Anisotropy/tif",
             "Ordering": 0,
             "PaddingDigits": 3,
             "StartIndex": 0
@@ -53,9 +57,11 @@
         }
     },
     "2": {
-        "FilterVersion": "6.2.327",
+        "FilterVersion": "6.5.77",
+        "Filter_Enabled": true,
         "Filter_Human_Label": "Convert Orientation Representation",
         "Filter_Name": "ConvertOrientations",
+        "Filter_Uuid": "{e5629880-98c4-5656-82b8-c9fe2b9744de}",
         "InputOrientationArrayPath": {
             "Attribute Matrix Name": "EBSD & SEM Scan Data",
             "Data Array Name": "EulerAngles",
@@ -66,7 +72,7 @@
         "OutputType": 2
     },
     "3": {
-        "AlignmentShiftFileName": "TestDataAdaptiveAlignment-MutualInformation-SEMImages.txt",
+        "AlignmentShiftFileName": "Data/Output/Anisotropy/TestDataAdaptiveAlignment-MutualInformation-SEMImages.txt",
         "CellPhasesArrayPath": {
             "Attribute Matrix Name": "EBSD & SEM Scan Data",
             "Data Array Name": "Phases",
@@ -77,20 +83,35 @@
             "Data Array Name": "CrystalStructures",
             "Data Container Name": "AlMgSc Data"
         },
-        "FilterVersion": "6.2.327",
+        "FilterVersion": "1.2.724",
+        "Filter_Enabled": true,
         "Filter_Human_Label": "Adaptive Alignment (Mutual Information)",
         "Filter_Name": "AdaptiveAlignmentMutualInformation",
+        "Filter_Uuid": "{738c8da9-45d0-53dd-aa54-3f3a337b70d7}",
         "GlobalCorrection": 1,
         "GoodVoxelsArrayPath": {
             "Attribute Matrix Name": "EBSD & SEM Scan Data",
             "Data Array Name": "",
             "Data Container Name": "AlMgSc Data"
         },
+        "IgnoredDataArrayPaths": [
+            {
+                "Attribute Matrix Name": "EBSD & SEM Scan Data",
+                "Data Array Name": "X Position",
+                "Data Container Name": "AlMgSc Data"
+            },
+            {
+                "Attribute Matrix Name": "EBSD & SEM Scan Data",
+                "Data Array Name": "Y Position",
+                "Data Container Name": "AlMgSc Data"
+            }
+        ],
         "ImageDataArrayPath": {
-            "Attribute Matrix Name": "EBSD & SEM Scan Data",
+            "Attribute Matrix Name": "EBSD SEM Scan Data",
             "Data Array Name": "ImageData",
             "Data Container Name": "SEMAlMgSc Data"
         },
+        "MisorientationTolerance": 5,
         "QuatsArrayPath": {
             "Attribute Matrix Name": "EBSD & SEM Scan Data",
             "Data Array Name": "Quats",
@@ -104,6 +125,6 @@
     "PipelineBuilder": {
         "Name": "03_Adaptive Alignment - Mutual Information - SEM Images",
         "Number_Filters": 4,
-        "Version": "6.2"
+        "Version": 6
     }
 }

--- a/ExamplePipelines/Anisotropy/04_Steiner Compact.json
+++ b/ExamplePipelines/Anisotropy/04_Steiner Compact.json
@@ -1,22 +1,29 @@
 {
     "0": {
+        "AngleRepresentation": 0,
         "CellAttributeMatrixName": "EBSD & SEM Scan Data",
         "CellEnsembleAttributeMatrixName": "Phase Data",
         "DataContainerName": "AlMgSc Data",
-        "FilterVersion": "6.2.327",
-        "Filter_Human_Label": "Read H5EBSD File",
+        "FilterVersion": "6.5.77",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Import H5EBSD File",
         "Filter_Name": "ReadH5Ebsd",
-        "InputFile": "Data/AlMgSc.h5ebsd",
-        "RefFrameZDir": 2,
+        "Filter_Uuid": "{4ef7f56b-616e-5a80-9e68-1da8f35ad235}",
+        "InputFile": "Data/Anisotropy/AlMgSc.h5ebsd",
+        "RefFrameZDir": 0,
         "SelectedArrayNames": [
-            "SEM Signal",
             "Image Quality",
-            "Confidence Index",
-            "X Position",
             "Y Position",
-            "Fit",
             "Phases",
-            "EulerAngles"
+            "X Position",
+            "Confidence Index",
+            "Fit",
+            "Phi1",
+            "Phi",
+            "PhaseData",
+            "EulerAngles",
+            "SEM Signal",
+            "Phi2"
         ],
         "UseTransformations": 1,
         "ZEndIndex": 9,
@@ -24,15 +31,17 @@
     },
     "1": {
         "DestinationArrayName": "Mask",
-        "FilterVersion": "6.2.327",
+        "FilterVersion": "1.2.724",
+        "Filter_Enabled": true,
         "Filter_Human_Label": "Threshold Objects",
         "Filter_Name": "MultiThresholdObjects",
+        "Filter_Uuid": "{014b7300-cf36-5ede-a751-5faf9b119dae}",
         "SelectedThresholds": [
             {
                 "Attribute Array Name": "Confidence Index",
                 "Attribute Matrix Name": "EBSD & SEM Scan Data",
                 "Comparison Operator": 1,
-                "Comparison Value": 0.05,
+                "Comparison Value": 0.05000000074505806,
                 "Data Container Name": "AlMgSc Data"
             },
             {
@@ -45,9 +54,11 @@
         ]
     },
     "2": {
-        "FilterVersion": "6.2.327",
+        "FilterVersion": "6.5.77",
+        "Filter_Enabled": true,
         "Filter_Human_Label": "Convert Orientation Representation",
         "Filter_Name": "ConvertOrientations",
+        "Filter_Uuid": "{e5629880-98c4-5656-82b8-c9fe2b9744de}",
         "InputOrientationArrayPath": {
             "Attribute Matrix Name": "EBSD & SEM Scan Data",
             "Data Array Name": "EulerAngles",
@@ -68,9 +79,11 @@
             "Data Array Name": "CrystalStructures",
             "Data Container Name": "AlMgSc Data"
         },
-        "FilterVersion": "6.2.327",
+        "FilterVersion": "6.5.77",
+        "Filter_Enabled": true,
         "Filter_Human_Label": "Neighbor Orientation Comparison (Bad Data)",
         "Filter_Name": "BadDataNeighborOrientationCheck",
+        "Filter_Uuid": "{f4a7c2df-e9b0-5da9-b745-a862666d6c99}",
         "GoodVoxelsArrayPath": {
             "Attribute Matrix Name": "EBSD & SEM Scan Data",
             "Data Array Name": "Mask",
@@ -100,11 +113,25 @@
             "Data Array Name": "CrystalStructures",
             "Data Container Name": "AlMgSc Data"
         },
-        "FilterVersion": "6.2.327",
+        "FilterVersion": "6.5.77",
+        "Filter_Enabled": true,
         "Filter_Human_Label": "Neighbor Orientation Correlation",
         "Filter_Name": "NeighborOrientationCorrelation",
+        "Filter_Uuid": "{6427cd5e-0ad2-5a24-8847-29f8e0720f4f}",
+        "IgnoredDataArrayPaths": [
+            {
+                "Attribute Matrix Name": "EBSD & SEM Scan Data",
+                "Data Array Name": "X Position",
+                "Data Container Name": "AlMgSc Data"
+            },
+            {
+                "Attribute Matrix Name": "EBSD & SEM Scan Data",
+                "Data Array Name": "Y Position",
+                "Data Container Name": "AlMgSc Data"
+            }
+        ],
         "Level": 2,
-        "MinConfidence": 0.05,
+        "MinConfidence": 0.05000000074505806,
         "MisorientationTolerance": 2,
         "QuatsArrayPath": {
             "Attribute Matrix Name": "EBSD & SEM Scan Data",
@@ -126,9 +153,11 @@
             "Data Container Name": "AlMgSc Data"
         },
         "FeatureIdsArrayName": "FeatureIds",
-        "FilterVersion": "6.2.327",
+        "FilterVersion": "6.5.77",
+        "Filter_Enabled": true,
         "Filter_Human_Label": "Segment Features (Misorientation)",
         "Filter_Name": "EBSDSegmentFeatures",
+        "Filter_Uuid": "{7861c691-b821-537b-bd25-dc195578e0ea}",
         "GoodVoxelsArrayPath": {
             "Attribute Matrix Name": "EBSD & SEM Scan Data",
             "Data Array Name": "Mask",
@@ -149,9 +178,23 @@
             "Data Array Name": "FeatureIds",
             "Data Container Name": "AlMgSc Data"
         },
-        "FilterVersion": "6.2.327",
+        "FilterVersion": "6.5.77",
+        "Filter_Enabled": true,
         "Filter_Human_Label": "Erode/Dilate Bad Data",
         "Filter_Name": "ErodeDilateBadData",
+        "Filter_Uuid": "{3adfe077-c3c9-5cd0-ad74-cf5f8ff3d254}",
+        "IgnoredDataArrayPaths": [
+            {
+                "Attribute Matrix Name": "EBSD & SEM Scan Data",
+                "Data Array Name": "X Position",
+                "Data Container Name": "AlMgSc Data"
+            },
+            {
+                "Attribute Matrix Name": "EBSD & SEM Scan Data",
+                "Data Array Name": "Y Position",
+                "Data Container Name": "AlMgSc Data"
+            }
+        ],
         "NumIterations": 3,
         "XDirOn": 1,
         "YDirOn": 1,
@@ -168,19 +211,21 @@
             "Data Array Name": "FeatureIds",
             "Data Container Name": "AlMgSc Data"
         },
-        "FilterVersion": "6.2.327",
+        "FilterVersion": "1.2.724",
+        "Filter_Enabled": true,
         "Filter_Human_Label": "Steiner Compact",
         "Filter_Name": "SteinerCompact",
+        "Filter_Uuid": "{07b1048e-d6d4-56d0-8cc5-132ac79bdf60}",
         "Plane": 0,
         "Sites": 1,
-        "TxtFileName": "SteinerCompactXY.txt",
+        "TxtFileName": "Data/Output/Anisotropy/SteinerCompactXY.txt",
         "TxtOutput": 1,
-        "VtkFileName": "SteinerCompactXY.vtk",
+        "VtkFileName": "Data/Output/Anisotropy/SteinerCompactXY.vtk",
         "VtkOutput": 1
     },
     "PipelineBuilder": {
         "Name": "04_Steiner Compact",
         "Number_Filters": 8,
-        "Version": "6.2"
+        "Version": 6
     }
 }


### PR DESCRIPTION
These filters perform actions where data from neighboring voxels are copied into
the current voxel. Some types of data such as voxel position data should never
be over written with other data, at least not during these filter operations.
This commit adds a MultiDataArraySelectionWidget to the filter to allow the user
to select DataArrays that are ignored during the copyTuple phase of the filter.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>